### PR TITLE
Refactor/crawler oop implementation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,11 +7,13 @@ on:
       - 'develop'
       - 'refactor/project-structure'
       - 'fix/integration-test'
+      - 'refactor/crawler-oop-implementation'
   pull_request:
     branches:
       - 'main'
       - 'develop'
       - 'refactor/project-structure'
+      - 'fix/integration-test'
   workflow_dispatch:
 jobs:
   test:
@@ -45,6 +47,13 @@ jobs:
         run: |
           cd backend
           pytest tests/integration --cov=src --cov-report=xml --disable-warnings
+
+      - name: Run unit tests
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          cd backend
+          pytest tests/unit --cov=src --cov-report=xml --disable-warnings
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/backend/src/crawler/crawler_base.py
+++ b/backend/src/crawler/crawler_base.py
@@ -1,0 +1,140 @@
+import abc
+from pydantic import AnyHttpUrl
+from tldextract import tldextract
+from sqlalchemy.orm import Session
+
+from src.crawler.exceptions import DomainMismatchException
+
+from pydantic import BaseModel, Field, AnyHttpUrl
+
+
+class Headline(BaseModel):
+    title: str = Field(
+        default=...,
+        example="Title of the article",
+        description="The title of the article"
+    )
+    url: AnyHttpUrl | str = Field(
+        default=...,
+        example="https://www.example.com",
+        description="The URL of the article"
+    )
+
+
+class News(Headline):
+    time: str = Field(
+        default=...,
+        example="2021-10-01T00:00:00",
+        description="The time the article was published"
+    )
+    content: str = Field(
+        default=...,
+        example="Content of the article",
+        description="The content of the article"
+    )
+
+
+class NewsWithSummary(News):
+    summary: str = Field(
+        default=...,
+        example="Summary of the article",
+        description="The summary of the article"
+    )
+    reason: str = Field(
+        default=...,
+        example="Reason of the article",
+        description="The reason of the article"
+    )
+
+
+class NewsCrawlerBase(metaclass=abc.ABCMeta):
+    news_website_url: AnyHttpUrl | str
+    news_website_news_child_urls: list[AnyHttpUrl | str]
+
+    @abc.abstractmethod
+    def get_headline(
+            self, search_term: str, page: int | tuple[int, int]
+    ) -> list[Headline]:
+        """
+        Searches for news headlines on the news website based on a given search term and returns a list of headlines.
+
+        This method searches through the entire news_website_url using the specified search term, and returns a list
+        of Headline namedtuples, where each Headline includes the title and URL of a news article. The page parameter
+        can be an integer representing a single page number or a tuple representing a range of page numbers to search
+        through.
+        # The offset and limit parameters apply to the resulting list of headlines, allowing you to skip a
+        # certain number of headlines and limit the number of headlines returned, respectively.
+
+        :param search_term: A search term to search for news articles.
+        :param page: A page number (int) or a tuple of start and end page numbers (tuple[int, int]).
+        # :param offset: The number of headlines to skip from the beginning of the list.
+        # :param limit: The maximum number of headlines to return.
+        :return: A list of Headline namedtuple  s, each containing a title and a URL.
+        """
+        return NotImplemented
+
+    @abc.abstractmethod
+    def parse(self, url: AnyHttpUrl | str) -> News:
+        """
+        Given a news URL from the news website, fetch and parse the detailed news content.
+
+        This method takes a URL that belongs to a news article on the news_website_url, retrieves the full content of
+        the news article, and returns it in the form of a News namedtuple. The News namedtuple includes the title,
+        URL, publication time, and content of the news article.
+
+        :param url: The URL of the news article to be fetched and parsed.
+        :return: A News namedtuple containing the title, URL, time, and content of the news article.
+        """
+
+        return NotImplemented
+
+    def validate_and_parse(self, url: AnyHttpUrl | str) -> News:
+        """
+        Validates the given URL and ensures that it belongs to the news website or its child URLs. If the URL is valid,
+        it proceeds with parsing the news content by invoking the `parse` method from the child class.
+
+        This method first checks if the provided URL is valid for the current news website. If the URL is not valid,
+        it raises a `DomainMismatchException`. If the URL is valid, the method passes the URL to the `parse` method
+        (which should be implemented in the child class) to retrieve and parse the news content.
+
+        :param url: The URL of the news article to be validated and parsed.
+        :return: A `News` object containing the parsed news details (title, URL, time, and content).
+        :raises DomainMismatchException: If the URL does not belong to the allowed domain or its child URLs.
+        """
+
+        if not self._is_valid_url(url):
+            raise DomainMismatchException(url)
+        return self.parse(url)
+
+
+    @staticmethod
+    @abc.abstractmethod
+    def save(news: News, db: Session | None):
+        """
+        Save the news content to a persistent storage.
+
+        This method takes a News namedtuple containing the title, URL, publication time, and content of a news article,
+        and saves it to a persistent storage, such as a database. The method should handle the storage of the news
+        content, ensuring that duplicate news articles are not saved.
+
+        :param news: A News namedtuple containing the title, URL, time, and content of the news article.
+        :param db: An instance of the database session to use for saving the news content.
+        """
+        return NotImplemented
+
+    def _is_valid_url(self, url: AnyHttpUrl | str) -> bool:
+        """
+        Check if the given URL belongs to the news website or its child URLs.
+
+        This method checks if the given URL belongs to the news_website_url or any of its child URLs. It returns True if
+        the URL is valid, and False otherwise.
+
+        :param url: The URL to be checked for validity.
+        :return: True if the URL is valid, False otherwise.
+        """
+        main_domain = tldextract.extract(self.news_website_url).registered_domain
+        url_domain = tldextract.extract(url).registered_domain
+
+        if url_domain == main_domain:
+            return True
+        return False

--- a/backend/src/crawler/exceptions.py
+++ b/backend/src/crawler/exceptions.py
@@ -1,0 +1,11 @@
+class DomainMismatchException(Exception):
+    """Exception raised for URLs whose domain does not match the news website's domain."""
+
+    def __init__(
+        self,
+        url: str,
+        message: str = "URL's domain does not match the news website's domain",
+    ):
+        self.url = url
+        self.message = message
+        super().__init__(self.message)

--- a/backend/src/crawler/udn_crawler.py
+++ b/backend/src/crawler/udn_crawler.py
@@ -1,0 +1,153 @@
+"""
+UDN News Scraper Module
+
+This module provides the UDNCrawler class for fetching, parsing, and saving news articles from the UDN website.
+The class extends the NewsCrawlerBase and includes functionalities to search for news articles based on a search term,
+parse the details of individual articles, and save them to a database using SQLAlchemy ORM.
+
+Classes:
+    UDNCrawler: A class to scrape news from UDN.
+
+Exceptions:
+    DomainMismatchException: Raised when the URL domain does not match the expected domain for the crawler.
+
+Usage Example:
+    crawler = UDNCrawler(timeout=10)
+    headlines = crawler.startup("technology")
+    for headline in headlines:
+        news = crawler.parse(headline.url)
+        crawler.save(news, db_session)
+
+UDNCrawler Methods:
+    __init__(self, timeout: int = 5): Initializes the crawler with a default timeout for HTTP requests.
+    startup(self, search_term: str) -> list[Headline]: Fetches news headlines for a given search term across multiple pages.
+    get_headline(self, search_term: str, page: int | tuple[int, int]) -> list[Headline]: Fetches news headlines for specified pages.
+    _fetch_news(self, page: int, search_term: str) -> list[Headline]: Helper method to fetch news headlines for a specific page.
+    _create_search_params(self, page: int, search_term: str): Creates the parameters for the search request.
+    _perform_request(self, params: dict): Performs the HTTP request to fetch news data.
+    _parse_headlines(response): Parses the response to extract headlines.
+    parse(self, url: str) -> News: Parses a news article from a given URL.
+    _extract_news(soup, url: str) -> News: Extracts news details from the BeautifulSoup object.
+    save(self, news: News, db: Session): Saves a news article to the database.
+    _commit_changes(db: Session): Commits the changes to the database with error handling.
+"""
+
+from requests import Response
+from bs4 import BeautifulSoup
+from sqlalchemy.orm import Session
+from urllib.parse import quote
+import requests
+
+from src.crawler.crawler_base import NewsCrawlerBase, Headline, News, NewsWithSummary, DomainMismatchException
+
+
+class UDNCrawler(NewsCrawlerBase):
+    CHANNEL_ID = 2
+
+    def __init__(self, timeout: int = 5) -> None:
+        self.news_website_url = "https://udn.com/api/more"
+        self.timeout = timeout
+
+#----------------------------------------------------------------------------------#
+# First fetch news, return to openAi, select the high relenvance ones and bs4 them #
+#----------------------------------------------------------------------------------#
+
+    def startup(self, search_term: str) -> list[Headline]:
+        """
+        Initializes the application by fetching news headlines for a given search term across multiple pages.
+        This method is typically called at the beginning of the program when there is no data available,
+        hence it fetches headlines from the first 10 pages.
+
+        :param search_term: The term to search for in news headlines.
+        :return: A list of Headline namedtuples containing the title and URL of news articles.
+        :rtype: list[Headline]
+        """
+        return self.get_headline(search_term, page=(1, 10))
+
+    def get_headline(self, search_term: str, page: int | tuple[int, int]) -> list[Headline]:
+
+        # Calculate the range of pages to fetch news from.
+        # If 'page' is a tuple, unpack it and create a range representing those pages (inclusive).
+        # If 'page' is an int, create a list containing only that single page number.
+        # page_range = range(*page) if isinstance(page, tuple) else [page]
+
+        all_news_title_and_url = []
+        if isinstance(page, int):
+            news = self._fetch_news(page, search_term)
+            all_news_title_and_url.extend(news)
+            return all_news_title_and_url
+        
+        for p in range(page[0], page[1] + 1):
+            news = self._fetch_news(p, search_term)
+            all_news_title_and_url.extend(news)
+        return all_news_title_and_url
+
+    def _fetch_news(self, page: int, search_term: str) -> list[Headline]:
+
+        params = self._create_search_params(page, search_term)
+        response = self._perform_request(self.news_website_url, params)
+
+        return self._parse_headlines(response.json()["lists"])
+
+    def _create_search_params(self, page: int, search_term: str) -> dict:
+
+        params = {
+            "page": page,   
+            "id": f"search:{quote(search_term)}",
+            "channelId": 2,
+            "type": "searchword",
+        }
+        return params
+
+    def _perform_request(self, url: str | None = None, params: dict | None = None) -> Response:
+        if self._is_valid_url(url) is False:
+            raise DomainMismatchException(url=url)
+
+        response = requests.get(url, params=params)
+        return response
+
+
+    @staticmethod
+    def _parse_headlines(response: Response) -> list[Headline]:
+        headlines = []
+        for item in response:
+            headline = Headline(
+                title=item["title"],
+                url=item["titleLink"]
+            )
+            headlines.append(headline)
+        return headlines
+
+#------------------------------------------------------------#
+# After OpenAI selection, parse the selected news one by one #
+#------------------------------------------------------------#
+    def parse(self, url: str) -> News:
+        response = self._perform_request(url=url)
+        soup = BeautifulSoup(response.text, "html.parser")
+        return self._extract_news(soup, url)
+
+    @staticmethod
+    def _extract_news(soup: BeautifulSoup, url: str) -> News:
+        title = soup.find("h1", class_="article-content__title").text
+        time = soup.find("time", class_="article-content__time").text
+        content_section = soup.find("section", class_="article-content__paragraph")
+        paragraphs = [
+                p.text
+                for p in content_section.find_all("p")
+                if p.text.strip() != "" and "▪" not in p.text
+            ]
+        content = " ".join(paragraphs)
+        return News(
+            title=title,
+            url=url,
+            time=time,
+            content=content
+        )
+
+    def save(self, news: NewsWithSummary, db: Session):
+        db.add(news)
+        self._commit_changes(db)
+
+    @staticmethod
+    def _commit_changes(db: Session):
+        db.commit()

--- a/backend/src/crawler/udn_crawler.py
+++ b/backend/src/crawler/udn_crawler.py
@@ -100,6 +100,10 @@ class UDNCrawler(NewsCrawlerBase):
         return params
 
     def _perform_request(self, url: str | None = None, params: dict | None = None) -> Response:
+
+        if url is None:
+            url = self.news_website_url
+
         if self._is_valid_url(url) is False:
             raise DomainMismatchException(url=url)
 
@@ -130,7 +134,7 @@ class UDNCrawler(NewsCrawlerBase):
     def _extract_news(soup: BeautifulSoup, url: str) -> News:
         title = soup.find("h1", class_="article-content__title").text
         time = soup.find("time", class_="article-content__time").text
-        content_section = soup.find("section", class_="article-content__paragraph")
+        content_section = soup.find("section", class_="article-content__editor")
         paragraphs = [
                 p.text
                 for p in content_section.find_all("p")

--- a/backend/src/crawler/udn_crawler.py
+++ b/backend/src/crawler/udn_crawler.py
@@ -64,7 +64,7 @@ class UDNCrawler(NewsCrawlerBase):
         """
         return self.get_headline(search_term, page=(1, 10))
 
-    def get_headline(self, search_term: str, page: int | tuple[int, int]) -> list[Headline]:
+    def get_headline(self, search_term: str, page: int | tuple[int, int] = 1 ) -> list[Headline]:
 
         # Calculate the range of pages to fetch news from.
         # If 'page' is a tuple, unpack it and create a range representing those pages (inclusive).

--- a/backend/src/news/dependencies.py
+++ b/backend/src/news/dependencies.py
@@ -1,6 +1,7 @@
 from fastapi import Depends
 from sqlalchemy.orm import Session
-from src.news.service import NewsService, OpenAIService, NewsScraperService, UpvoteService
+from src.news.service import NewsService, OpenAIService, UpvoteService
+from src.crawler.udn_crawler import UDNCrawler
 from src.database import get_db
 from src.news.config import OPENAI_API_KEY
 
@@ -12,7 +13,7 @@ def get_news_service(
     db: Session = Depends(get_db),
     openai_service: OpenAIService = Depends(get_openai_service)
 ):
-    scraper_service = NewsScraperService()
+    scraper_service = UDNCrawler()
     return NewsService(db, openai_service, scraper_service)
 
 

--- a/backend/src/news/scheduler.py
+++ b/backend/src/news/scheduler.py
@@ -3,18 +3,18 @@ from src.database import SessionLocal
 from src.news.service import NewsService, OpenAIService, NewsScraperService
 from src.news.models import NewsArticle
 from src.news.config import OPENAI_API_KEY
-
+from src.crawler.udn_crawler import UDNCrawler
 
 class NewsScheduler:
     
     def __init__(self):
         self.background_scheduler = BackgroundScheduler()
-
+        self.udn_crawler = UDNCrawler()
     def start(self):
         db = SessionLocal()
         if db.query(NewsArticle).count() == 0:
             openai_service = OpenAIService(api_key=OPENAI_API_KEY)
-            scraper_service = NewsScraperService()
+            scraper_service = self.udn_crawler
             news_service = NewsService(db, openai_service, scraper_service)
             news_service.fetch_and_store_news(is_initial=True)
     
@@ -23,7 +23,7 @@ class NewsScheduler:
         def fetch_news_job():
             db = SessionLocal()
             openai_service = OpenAIService(api_key=OPENAI_API_KEY)
-            scraper_service = NewsScraperService()
+            scraper_service = self.udn_crawler
             news_service = NewsService(db, openai_service, scraper_service)
             news_service.fetch_and_store_news(is_initial=False)
             db.close()

--- a/backend/src/news/scheduler.py
+++ b/backend/src/news/scheduler.py
@@ -1,6 +1,6 @@
 from apscheduler.schedulers.background import BackgroundScheduler
 from src.database import SessionLocal
-from src.news.service import NewsService, OpenAIService, NewsScraperService
+from src.news.service import NewsService, OpenAIService
 from src.news.models import NewsArticle
 from src.news.config import OPENAI_API_KEY
 from src.crawler.udn_crawler import UDNCrawler

--- a/backend/src/news/service.py
+++ b/backend/src/news/service.py
@@ -9,6 +9,7 @@ from sqlalchemy import select, insert, delete
 from openai import OpenAI
 from src.news.models import NewsArticle, user_news_association_table
 from src.news.config import NewsConfig
+from src.crawler.udn_crawler import UDNCrawler, NewsWithSummary
 
 class OpenAIService:
     
@@ -69,7 +70,7 @@ class NewsScraperService:
     @staticmethod
     def fetch_news_list(search_term: str, page: int = 1) -> List[dict]:
         params = {
-            "page": page,
+            "page": page,   
             "id": f"search:{quote(search_term)}",
             "channelId": 2,
             "type": "searchword",
@@ -114,10 +115,10 @@ class NewsScraperService:
 
 class NewsService:
     
-    def __init__(self, db: Session, openai_service: OpenAIService, scraper_service: NewsScraperService):
+    def __init__(self, db: Session, openai_service: OpenAIService, scraper_service: UDNCrawler):
         self.db = db
         self.openai_service = openai_service
-        self.scraper_service = scraper_service
+        self.udn_service = scraper_service
         self._id_counter = itertools.count(start=1000000)
     
     def add_article_to_db(self, news_data: dict) -> None:
@@ -134,38 +135,50 @@ class NewsService:
     
     def fetch_and_store_news(self, search_term: str = "價格", is_initial: bool = False) -> None:
         if is_initial:
-            news_list = self.scraper_service.fetch_news_list_multiple_pages(search_term)
+            news_list = self.udn_service.startup(search_term)
         else:
-            news_list = self.scraper_service.fetch_news_list(search_term)
+            news_list = self.udn_service.get_headline(search_term, page=1)
         
         for news_item in news_list:
-            relevance = self.openai_service.assess_relevance(news_item["title"])
+            relevance = self.openai_service.assess_relevance(news_item.title)
             
             if relevance == "high":
-                detailed_news = self.scraper_service.scrape_article_details(news_item["titleLink"])
+                detailed_news = self.udn_service.parse(news_item.url)
                 
                 if detailed_news:
-                    content_text = " ".join(detailed_news["content"])
-                    summary_data = self.openai_service.generate_summary(content_text)
+                    summary_data = self.openai_service.generate_summary(detailed_news.content)
                     
-                    detailed_news["summary"] = summary_data["影響"]
-                    detailed_news["reason"] = summary_data["原因"]
+                    detailed_news.summary = summary_data["影響"]
+                    detailed_news.reason = summary_data["原因"]
+                    news_with_summary = NewsWithSummary(
+                        title=detailed_news.title,
+                        url=detailed_news.url,
+                        time=detailed_news.time,
+                        content=detailed_news.content,
+                        summary=detailed_news.summary,
+                        reason=detailed_news.reason
+                    )
+                    self.udn_service.save(news_with_summary, self.db)
                     
-                    self.add_article_to_db(detailed_news)
     
     def search_news(self, prompt: str) -> List[dict]:
         keywords = self.openai_service.extract_keywords(prompt)
         
-        news_items = self.scraper_service.fetch_news_list(keywords)
+        news_items = self.udn_service.get_headline(keywords, page=1)
         
         news_list = []
         for news_item in news_items:
-            detailed_news = self.scraper_service.scrape_article_details(news_item["titleLink"])
+            detailed_news = self.udn_service.parse(news_item.url)
             
             if detailed_news:
-                detailed_news["content"] = " ".join(detailed_news["content"])
-                detailed_news["id"] = next(self._id_counter)
-                news_list.append(detailed_news)
+                listed_news = {
+                    "title": detailed_news.title,
+                    "url": detailed_news.url,
+                    "time": detailed_news.time,
+                    "content": detailed_news.content,
+                }
+                listed_news["id"] = next(self._id_counter)
+                news_list.append(listed_news)
         
         return sorted(news_list, key=lambda x: x["time"], reverse=True)
     

--- a/backend/src/news/service.py
+++ b/backend/src/news/service.py
@@ -63,56 +63,6 @@ class OpenAIService:
         )
         return completion.choices[0].message.content
 
-
-class NewsScraperService:
-    
-    
-    @staticmethod
-    def fetch_news_list(search_term: str, page: int = 1) -> List[dict]:
-        params = {
-            "page": page,   
-            "id": f"search:{quote(search_term)}",
-            "channelId": 2,
-            "type": "searchword",
-        }
-        response = requests.get(NewsConfig.UDN_API_URL, params=params)
-        return response.json()["lists"]
-    
-    @staticmethod
-    def fetch_news_list_multiple_pages(search_term: str, num_pages: int = 9) -> List[dict]:
-        all_news = []
-        for page in range(1, num_pages + 1):
-            news_list = NewsScraperService.fetch_news_list(search_term, page)
-            all_news.extend(news_list)
-        return all_news
-    
-    @staticmethod
-    def scrape_article_details(url: str) -> Optional[dict]:
-        try:
-            response = requests.get(url)
-            soup = BeautifulSoup(response.text, "html.parser")
-            
-            title = soup.find("h1", class_="article-content__title").text
-            time = soup.find("time", class_="article-content__time").text
-            content_section = soup.find("section", class_="article-content__editor")
-            
-            paragraphs = [
-                p.text
-                for p in content_section.find_all("p")
-                if p.text.strip() != "" and "▪" not in p.text
-            ]
-            
-            return {
-                "url": url,
-                "title": title,
-                "time": time,
-                "content": paragraphs,
-            }
-        except Exception as e:
-            print(f"Error scraping article {url}: {e}")
-            return None
-
-
 class NewsService:
     
     def __init__(self, db: Session, openai_service: OpenAIService, scraper_service: UDNCrawler):

--- a/backend/src/news/service.py
+++ b/backend/src/news/service.py
@@ -13,7 +13,7 @@ from src.crawler.udn_crawler import UDNCrawler, NewsWithSummary
 
 class OpenAIService:
     
-    def __init__(self, api_key: str, model: str = "gpt-3.5-turbo"):
+    def __init__(self, api_key: str, model: str = "gpt-4o-mini"):
         self.client = OpenAI(api_key=api_key)
         self.model = model
     

--- a/backend/tests/integration/test_news_endpoint.py
+++ b/backend/tests/integration/test_news_endpoint.py
@@ -12,6 +12,8 @@ from src.auth.models import User
 
 from src.news.schemas import NewsSummaryRequestSchema
 from src.auth.config import PWD_CONTEXT as pwd_context
+from src.crawler.crawler_base import Headline
+
 from unittest.mock import Mock
 
 
@@ -135,13 +137,13 @@ def mock_openai(mocker, return_content):
 def test_search_news(mocker):
     mock_openai(mocker, "keywords")
 
-    mocker.patch("src.news.service.NewsScraperService.fetch_news_list_multiple_pages", return_value=[
-        {"titleLink": "http://example.com/news1"}
+    mocker.patch("src.crawler.udn_crawler.UDNCrawler.get_headline", return_value=[
+        Headline(title="Test Title", url="http://example.udn.com/news1")
     ])
 
     mock_response = mocker.Mock()
     mock_response.json.return_value = {"lists": [
-        {"titleLink": "http://example.com/news1"}
+        {"titleLink": "http://example.udn.com/news1"}
     ]}
     mock_response.text = """
         <html>

--- a/backend/tests/unit/__init__.py
+++ b/backend/tests/unit/__init__.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest.mock import patch
+from pydantic import AnyHttpUrl
+from src.crawler.udn_crawler import NewsCrawlerBase, News, Headline
+from src.crawler.exceptions import DomainMismatchException
+
+
+class MockNewsCrawler(NewsCrawlerBase):
+    news_website_url = "https://www.example.com"
+    news_website_news_child_urls = ["https://news.example.com"]
+
+    def get_headline(self, search_term: str, page: int | tuple[int, int]):
+        return [Headline(title="Test Article", url="https://www.example.com/article")]
+
+    def parse(self, url: AnyHttpUrl | str):
+        return News(
+            title="Test Article",
+            url=url,
+            time="2023-09-08T00:00:00",
+            content="This is the content of the article."
+        )
+
+    @staticmethod
+    def save(news: News, db=None):
+        return True
+
+
+class TestNewsCrawlerBase(unittest.TestCase):
+
+    def setUp(self):
+        self.crawler = MockNewsCrawler()
+
+    def test_is_valid_url_valid(self):
+        valid_url = "https://www.example.com/article"
+        self.assertTrue(self.crawler._is_valid_url(valid_url))
+
+    def test_is_valid_url_invalid(self):
+        invalid_url = "https://www.invalid.com/article"
+        self.assertFalse(self.crawler._is_valid_url(invalid_url))
+
+    def test_is_valid_url_child(self):
+        valid_child_url = "https://news.example.com/article"
+        self.assertTrue(self.crawler._is_valid_url(valid_child_url))
+
+    def test_is_valid_url_raises_domain_mismatch(self):
+        invalid_url = "https://www.invalid.com/article"
+
+        with self.assertRaises(DomainMismatchException):
+            self.crawler.validate_and_parse(invalid_url)
+
+    def test_get_headline(self):
+        headlines = self.crawler.get_headline(search_term="test", page=1)
+        self.assertEqual(len(headlines), 1)
+        self.assertEqual(headlines[0].title, "Test Article")
+        self.assertEqual(headlines[0].url, "https://www.example.com/article")
+
+    def test_parse(self):
+        news = self.crawler.parse("https://www.example.com/article")
+        self.assertEqual(news.title, "Test Article")
+        self.assertEqual(news.url, "https://www.example.com/article")
+        self.assertEqual(news.time, "2023-09-08T00:00:00")
+        self.assertEqual(news.content, "This is the content of the article.")
+
+    @patch('src.crawler.udn_crawler.Session')
+    def test_save(self, mock_db_session):
+        news = News(
+            title="Test Article",
+            url="https://www.example.com/article",
+            time="2023-09-08T00:00:00",
+            content="This is the content of the article."
+        )
+        result = self.crawler.save(news, mock_db_session)
+        self.assertTrue(result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/unit/test_base_crawler.py
+++ b/backend/tests/unit/test_base_crawler.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest.mock import patch
+from pydantic import AnyHttpUrl
+from src.crawler.udn_crawler import NewsCrawlerBase, News, Headline
+from src.crawler.exceptions import DomainMismatchException
+
+
+class MockNewsCrawler(NewsCrawlerBase):
+    news_website_url = "https://www.example.com"
+    news_website_news_child_urls = ["https://news.example.com"]
+
+    def get_headline(self, search_term: str, page: int | tuple[int, int]):
+        return [Headline(title="Test Article", url="https://www.example.com/article")]
+
+    def parse(self, url: AnyHttpUrl | str):
+        return News(
+            title="Test Article",
+            url=url,
+            time="2023-09-08T00:00:00",
+            content="This is the content of the article."
+        )
+
+    @staticmethod
+    def save(news: News, db=None):
+        return True
+
+
+class TestNewsCrawlerBase(unittest.TestCase):
+
+    def setUp(self):
+        self.crawler = MockNewsCrawler()
+
+    def test_is_valid_url_valid(self):
+        valid_url = "https://www.example.com/article"
+        self.assertTrue(self.crawler._is_valid_url(valid_url))
+
+    def test_is_valid_url_invalid(self):
+        invalid_url = "https://www.invalid.com/article"
+        self.assertFalse(self.crawler._is_valid_url(invalid_url))
+
+    def test_is_valid_url_child(self):
+        valid_child_url = "https://news.example.com/article"
+        self.assertTrue(self.crawler._is_valid_url(valid_child_url))
+
+    def test_is_valid_url_raises_domain_mismatch(self):
+        invalid_url = "https://www.invalid.com/article"
+
+        with self.assertRaises(DomainMismatchException):
+            self.crawler.validate_and_parse(invalid_url)
+
+    def test_get_headline(self):
+        headlines = self.crawler.get_headline(search_term="test", page=1)
+        self.assertEqual(len(headlines), 1)
+        self.assertEqual(headlines[0].title, "Test Article")
+        self.assertEqual(headlines[0].url, "https://www.example.com/article")
+
+    def test_parse(self):
+        news = self.crawler.parse("https://www.example.com/article")
+        self.assertEqual(news.title, "Test Article")
+        self.assertEqual(news.url, "https://www.example.com/article")
+        self.assertEqual(news.time, "2023-09-08T00:00:00")
+        self.assertEqual(news.content, "This is the content of the article.")
+
+    @patch('src.crawler.udn_crawler.Session')
+    def test_save(self, mock_db_session):
+        news = News(
+            title="Test Article",
+            url="https://www.example.com/article",
+            time="2023-09-08T00:00:00",
+            content="This is the content of the article."
+        )
+        result = self.crawler.save(news, mock_db_session)
+        self.assertTrue(result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/unit/test_udn_news_crawler.py
+++ b/backend/tests/unit/test_udn_news_crawler.py
@@ -1,0 +1,105 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from requests.models import Response
+from sqlalchemy.orm import Session
+from src.crawler.udn_crawler import UDNCrawler, NewsWithSummary
+from src.crawler.exceptions import DomainMismatchException
+
+
+
+class TestUDNCrawler(unittest.TestCase):
+
+    def setUp(self):
+        self.scraper = UDNCrawler(timeout=5)
+
+    @patch("src.crawler.udn_crawler.requests.get")
+    def test_perform_request_success(self, mock_get):
+        mock_response = MagicMock(spec=Response)
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        response = self.scraper._perform_request(params={"page": 1, "id": "search:technology"})
+        self.assertEqual(response, mock_response)
+        mock_get.assert_called_once()
+
+    @patch("src.crawler.udn_crawler.requests.get")
+    def test_perform_request_failure(self, mock_get):
+        mock_get.side_effect = Exception("Network Error")
+        with self.assertRaises(Exception):
+            self.scraper._perform_request(params={"page": 1, "id": "search:technology"})
+
+    @patch("src.crawler.udn_crawler.requests.get")
+    def test_fetch_news_data(self, mock_get):
+        mock_response = MagicMock(spec=Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "lists": [{"title": "Test News", "titleLink": "https://udn.com/news/test-news"}]
+        }
+        mock_get.return_value = mock_response
+
+        headlines = self.scraper._fetch_news(page=1, search_term="technology")
+        self.assertEqual(len(headlines), 1)
+        self.assertEqual(headlines[0].title, "Test News")
+        self.assertEqual(headlines[0].url, "https://udn.com/news/test-news")
+
+    @patch("src.crawler.udn_crawler.requests.get")
+    def test_parse_news(self, mock_get):
+        mock_response = MagicMock(spec=Response)
+        mock_response.status_code = 200
+        mock_response.text = """
+            <html>
+                <h1 class="article-content__title">Test Title</h1>
+                <time class="article-content__time">2023-09-08T00:00:00</time>
+                <section class="article-content__editor">
+                    <p>Content paragraph 1.</p>
+                    <p>Content paragraph 2.</p>
+                </section>
+            </html>
+        """
+        mock_get.return_value = mock_response
+
+        news = self.scraper.parse("https://udn.com/news/test-news")
+        self.assertEqual(news.title, "Test Title")
+        self.assertEqual(news.time, "2023-09-08T00:00:00")
+        self.assertEqual(news.content, "Content paragraph 1. Content paragraph 2.")
+
+    def test_create_search_params(self):
+        params = self.scraper._create_search_params(page=1, search_term="technology")
+        self.assertEqual(params["page"], 1)
+        self.assertEqual(params["id"], "search:technology")
+        self.assertEqual(params["channelId"], 2)
+
+    @patch("src.crawler.udn_crawler.Session")
+    def test_save_news(self, mock_session):
+        mock_db = MagicMock(spec=Session)
+        mock_db.query.return_value.filter_by.return_value.first.return_value = None
+
+        news = NewsWithSummary(
+            title="Test Title",
+            url="https://udn.com/news/test-news",
+            time="2023-09-08T00:00:00",
+            content="Test Content",
+            summary="Test Summary",
+            reason="Test Reason",
+        )
+        self.scraper.save(news, mock_db)
+
+        mock_db.add.assert_called_once()
+        self.assertEqual(mock_db.add.call_args[0][0].title, "Test Title")
+        mock_db.commit.assert_called_once()
+
+    def test_is_valid_url(self):
+        valid_url = "https://udn.com/news/test-news"
+        invalid_url = "https://example.com/news/test-news"
+
+        self.assertTrue(self.scraper._is_valid_url(valid_url))
+        self.assertFalse(self.scraper._is_valid_url(invalid_url))
+
+    def test_parse_invalid_domain(self):
+        invalid_url = "https://example.com/news/test-news"
+        with self.assertRaises(DomainMismatchException):
+            self.scraper.parse(invalid_url)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose
- Adding new UDNCrawler feature to the backend, replacing the orignal NewsScraperService

## Changes
- Adding 'crawler' directory under 'src' directory
    - __init__.py
    - crawler_base.py
    - exceptions.py
    - udn_crawler.py
- Deleting the NewsScrapperService
- Update the old ci testcases which is working on the NewsScaperService
- Adding unit test for the UDNCrawler feature
- Update .github/workflows/ci.yaml to make it run both tests once push or merge happenning